### PR TITLE
Nicely handle empty GITHUB_INCLUDE_REPOS

### DIFF
--- a/gunsub.py
+++ b/gunsub.py
@@ -106,8 +106,9 @@ https://github.com/jpetazzo/gunsub
         sys.exit(1)
     github_user = os.environ['GITHUB_USER']
     github_password = os.environ['GITHUB_PASSWORD']
-    github_include_repos = os.environ.get('GITHUB_INCLUDE_REPOS', '')
-    github_include_repos = github_include_repos.split(',')
+    github_include_repos = os.environ.get('GITHUB_INCLUDE_REPOS', None)
+    if github_include_repos:
+        github_include_repos = github_include_repos.split(',')
     github_exclude_repos = os.environ.get('GITHUB_EXCLUDE_REPOS', '')
     github_exclude_repos = github_exclude_repos.split(',')
     interval = os.environ.get('GITHUB_POLL_INTERVAL')


### PR DESCRIPTION
Hey @jpetazzo!

As I told you over twitter, I was having trouble getting gunsub to work down here and I ended up tracking it down to `github_include_repos` set to `['']` because of [this split](https://github.com/jpetazzo/gunsub/blob/a6051340090d6149228b7dd52beaaf612a96d02e/gunsub.py#L110) in case it is not provided and no project [would match with it](https://github.com/jpetazzo/gunsub/blob/a6051340090d6149228b7dd52beaaf612a96d02e/gunsub.py#L62-L64).

This is my first python PR ever, so apologies if somehow this could have been done in another way :-)
