### PR TITLE
Lots of usability improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu
 MAINTAINER jerome.petazzoni@dotcloud.com
-RUN apt-get install -qy python
+RUN apt-get install -qy python python-pandas
 ADD gunsub.py /gunsub.py
 CMD python /gunsub.py

--- a/gunsub.py
+++ b/gunsub.py
@@ -106,12 +106,12 @@ def gunsub(github_user, github_password,
         if not notifications:
             break
         for notification in notifications:
-            # Releases don't have subscribe or unsubscribe buttons on the
-            # Github web site, so don't mess with them.
-            if notification['subject']['type'] == 'Release':
-                continue
             # Check inclusion/exclusion rules.
             try:
+                # Releases don't have subscribe or unsubscribe buttons on the
+                # Github web site, so don't mess with them.
+                if notification['subject']['type'] == 'Release':
+                    continue
                 repo_name = notification['repository']['name']
             except TypeError:
                 # I once got "TypeError: string indices must be integers" from

--- a/gunsub.py
+++ b/gunsub.py
@@ -111,7 +111,17 @@ def gunsub(github_user, github_password,
             if notification['subject']['type'] == 'Release':
                 continue
             # Check inclusion/exclusion rules.
-            repo_name = notification['repository']['name']
+            try:
+                repo_name = notification['repository']['name']
+            except TypeError:
+                # I once got "TypeError: string indices must be integers" from
+                # the line of code above, which I couldn't debug because the
+                # resulting log message didn't say what was actually in the
+                # notification, so logging it here for the next time it
+                # happens.
+                log.error('Unexpected notification contents: {}'.format(
+                    notification))
+                raise
             if github_include_repos and \
                not repo_list_match(notification, github_include_repos):
                 continue

--- a/gunsub.py
+++ b/gunsub.py
@@ -5,6 +5,7 @@ import httplib
 import json
 import logging
 import os
+from pandas import Timestamp
 import sys
 from textwrap import wrap
 import time
@@ -141,6 +142,9 @@ def parse_args():
     parser.add_argument('--exclude', action='append', default=exclude_default,
                         help='List of repositories to exclude (or set '
                         '$GITHUB_EXCLUDE_REPOS to comma-separated list)')
+    parser.add_argument('--since', metavar='TIME-STRING', action='store',
+                        type=Timestamp, help='Examine notifications starting '
+                        'at the specified time')
 
     return parser.parse_args()
 
@@ -158,12 +162,16 @@ def main(args):
     since = None
 
     state_file = './next-since'
-    # Read application state
-    if os.path.isfile(state_file):
-        with open(state_file) as next_since_file:
-            since = float(next_since_file.read().split()[0])
-        log.info('Parsing events since {0}, {1}'
-                 .format(time.strftime('%FT%TZ', time.gmtime(since)), since))
+
+    if args.since:
+        since = int(args.since.strftime('%s'))
+    else:
+        # Read application state
+        if os.path.isfile(state_file):
+            with open(state_file) as next_since_file:
+                since = float(next_since_file.read().split()[0])
+                log.info('Parsing events since {0}, {1}'.format(
+                    time.strftime('%FT%TZ', time.gmtime(since)), since))
 
     while True:
         next_since = time.time()

--- a/gunsub.py
+++ b/gunsub.py
@@ -38,7 +38,7 @@ def send_email(address, notification):
             notification_type))
         return
 
-    msg = dedent("""
+    msg = dedent(u"""
         From: Gunsub <{0}>
         To: {0}
         Subject: Unsubscribed from "{1}"

--- a/gunsub.py
+++ b/gunsub.py
@@ -97,7 +97,7 @@ def gunsub(github_user, github_password,
 
     count = 0
     for page in iterpage():
-        notifications = req('/notifications?page={0}{1}'
+        notifications = req('/notifications?all=true&page={0}{1}'
                             .format(page, since_qs))
         if not notifications:
             break

--- a/gunsub.py
+++ b/gunsub.py
@@ -4,7 +4,6 @@ import httplib
 import json
 import logging
 import os
-import os.path
 import sys
 import time
 

--- a/gunsub.py
+++ b/gunsub.py
@@ -106,6 +106,10 @@ def gunsub(github_user, github_password,
         if not notifications:
             break
         for notification in notifications:
+            # Releases don't have subscribe or unsubscribe buttons on the
+            # Github web site, so don't mess with them.
+            if notification['subject']['type'] == 'Release':
+                continue
             # Check inclusion/exclusion rules.
             repo_name = notification['repository']['name']
             if github_include_repos and \

--- a/gunsub.py
+++ b/gunsub.py
@@ -1,5 +1,7 @@
 import argparse
 import base64
+import email
+import email.mime.text
 import fnmatch
 import httplib
 import json
@@ -38,11 +40,7 @@ def send_email(address, notification):
             notification_type))
         return
 
-    msg = dedent(u"""
-        From: Gunsub <{0}>
-        To: {0}
-        Subject: Unsubscribed from "{1}"
-
+    body = dedent(u"""
         You have been unsubscribed from the {2} with the subject
         "{1}".
 
@@ -50,9 +48,15 @@ def send_email(address, notification):
        """).lstrip().format(
            address, title, notification_type.lower(), url)
 
+    msg = email.mime.text.MIMEText(body, 'plain', 'utf-8')
+    msg['Subject'] = u'Unsubscribed from "{}"'.format(title)
+    msg['From'] = 'Gunsub <{}>'.format(address)
+    msg['To'] = address
+    
     smtp = smtplib.SMTP('localhost')
-    smtp.sendmail(address, [address], msg)
+    smtp.sendmail(address, [address], msg.as_string())
     smtp.quit()
+
 
 def repo_pattern_match(notification, pattern):
     name = notification['repository'][


### PR DESCRIPTION
1. Allow the include and exclude lists to use shell glob wildcards.
2. Allow the include and exclude lists to specify the repository owner (this and the previous change mean that you can, for example, put "organization/*" in the include or exclude list to exclude or limit to an entire user or organization).
3. Non-functional cleanup fix: It's not necessary to import `os.path` when `os` is imported.
4. Add argument parsing.
5. Add a `--since` argument to specify when to start.
6. Add a `--dryrun` flag to say what would be done without actually doing it.

Thanks for writing this tool. I hope you find these changes useful!
